### PR TITLE
fixes #15 change the websocket client to java http client from Undertow

### DIFF
--- a/websocket-router/pom.xml
+++ b/websocket-router/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>cluster</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-core</artifactId>
         </dependency>

--- a/websocket-router/src/main/java/com/networknt/websocket/router/JdkBackendWebSocketListener.java
+++ b/websocket-router/src/main/java/com/networknt/websocket/router/JdkBackendWebSocketListener.java
@@ -1,0 +1,108 @@
+package com.networknt.websocket.router;
+
+import io.undertow.websockets.core.WebSocketChannel;
+import io.undertow.websockets.core.WebSockets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.http.WebSocket;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * JDK WebSocket.Listener that receives messages from the backend server
+ * and forwards them to the Undertow frontend WebSocketChannel (client).
+ */
+public class JdkBackendWebSocketListener implements WebSocket.Listener {
+    private static final Logger LOG = LoggerFactory.getLogger(JdkBackendWebSocketListener.class);
+
+    private final WebSocketChannel frontendChannel;
+    private final String channelId;
+    private final StringBuilder textBuffer = new StringBuilder();
+
+    /**
+     * Constructs a new JdkBackendWebSocketListener.
+     *
+     * @param frontendChannel the Undertow WebSocketChannel to forward messages to
+     * @param channelId the channel identifier for logging
+     */
+    public JdkBackendWebSocketListener(WebSocketChannel frontendChannel, String channelId) {
+        this.frontendChannel = frontendChannel;
+        this.channelId = channelId;
+    }
+
+    @Override
+    public void onOpen(WebSocket webSocket) {
+        if (LOG.isTraceEnabled()) LOG.trace("Backend WebSocket connection opened for channelId: {}", channelId);
+        // Request the first message
+        webSocket.request(1);
+    }
+
+    @Override
+    public CompletionStage<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+        textBuffer.append(data);
+        if (last) {
+            String message = textBuffer.toString();
+            textBuffer.setLength(0);
+            if (LOG.isTraceEnabled()) LOG.trace("Received text from backend for channelId: {}, length: {}", channelId, message.length());
+            if (frontendChannel.isOpen()) {
+                CompletableFuture<Void> future = new CompletableFuture<>();
+                WebSockets.sendText(message, frontendChannel, new io.undertow.websockets.core.WebSocketCallback<Void>() {
+                    @Override
+                    public void complete(WebSocketChannel channel, Void context) {
+                        future.complete(null);
+                    }
+
+                    @Override
+                    public void onError(WebSocketChannel channel, Void context, Throwable throwable) {
+                        LOG.error("Failed to forward text message to frontend for channelId: {}", channelId, throwable);
+                        future.complete(null);
+                    }
+                });
+                webSocket.request(1);
+                return future;
+            }
+        }
+        webSocket.request(1);
+        return null;
+    }
+
+    @Override
+    public CompletionStage<?> onBinary(WebSocket webSocket, ByteBuffer data, boolean last) {
+        if (LOG.isTraceEnabled()) LOG.trace("Received binary from backend for channelId: {}", channelId);
+        if (frontendChannel.isOpen()) {
+            // Forward binary data to the frontend as-is via pooled buffer
+            WebSockets.sendBinary(data, frontendChannel, null);
+        }
+        webSocket.request(1);
+        return null;
+    }
+
+    @Override
+    public CompletionStage<?> onClose(WebSocket webSocket, int statusCode, String reason) {
+        if (LOG.isDebugEnabled()) LOG.debug("Backend WebSocket closed for channelId: {}, status: {}, reason: {}", channelId, statusCode, reason);
+        try {
+            if (frontendChannel.isOpen()) {
+                frontendChannel.setCloseCode(statusCode);
+                frontendChannel.setCloseReason(reason != null ? reason : "");
+                frontendChannel.sendClose();
+            }
+        } catch (Exception e) {
+            LOG.error("Error closing frontend channel for channelId: {}", channelId, e);
+        }
+        return null;
+    }
+
+    @Override
+    public void onError(WebSocket webSocket, Throwable error) {
+        LOG.error("Backend WebSocket error for channelId: {}", channelId, error);
+        try {
+            if (frontendChannel.isOpen()) {
+                frontendChannel.sendClose();
+            }
+        } catch (Exception e) {
+            LOG.error("Error closing frontend channel after backend error for channelId: {}", channelId, e);
+        }
+    }
+}

--- a/websocket-router/src/main/java/com/networknt/websocket/router/JdkBackendWebSocketListener.java
+++ b/websocket-router/src/main/java/com/networknt/websocket/router/JdkBackendWebSocketListener.java
@@ -5,10 +5,11 @@ import io.undertow.websockets.core.WebSockets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayOutputStream;
 import java.net.http.WebSocket;
 import java.nio.ByteBuffer;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * JDK WebSocket.Listener that receives messages from the backend server
@@ -20,6 +21,9 @@ public class JdkBackendWebSocketListener implements WebSocket.Listener {
     private final WebSocketChannel frontendChannel;
     private final String channelId;
     private final StringBuilder textBuffer = new StringBuilder();
+    // The JDK WebSocket spec guarantees listener methods are invoked sequentially,
+    // so these accumulation buffers do not require external synchronization.
+    private final ByteArrayOutputStream binaryBuffer = new ByteArrayOutputStream();
 
     /**
      * Constructs a new JdkBackendWebSocketListener.
@@ -51,32 +55,57 @@ public class JdkBackendWebSocketListener implements WebSocket.Listener {
                 WebSockets.sendText(message, frontendChannel, new io.undertow.websockets.core.WebSocketCallback<Void>() {
                     @Override
                     public void complete(WebSocketChannel channel, Void context) {
+                        webSocket.request(1);
                         future.complete(null);
                     }
 
                     @Override
                     public void onError(WebSocketChannel channel, Void context, Throwable throwable) {
                         LOG.error("Failed to forward text message to frontend for channelId: {}", channelId, throwable);
+                        webSocket.request(1);
                         future.complete(null);
                     }
                 });
-                webSocket.request(1);
                 return future;
             }
         }
         webSocket.request(1);
-        return null;
+        return CompletableFuture.completedFuture(null);
     }
 
     @Override
     public CompletionStage<?> onBinary(WebSocket webSocket, ByteBuffer data, boolean last) {
-        if (LOG.isTraceEnabled()) LOG.trace("Received binary from backend for channelId: {}", channelId);
-        if (frontendChannel.isOpen()) {
-            // Forward binary data to the frontend as-is via pooled buffer
-            WebSockets.sendBinary(data, frontendChannel, null);
+        // Copy JDK-owned ByteBuffer contents immediately — the buffer may be reused after return
+        byte[] chunk = new byte[data.remaining()];
+        data.get(chunk);
+        binaryBuffer.write(chunk, 0, chunk.length);
+
+        if (last) {
+            byte[] bytes = binaryBuffer.toByteArray();
+            binaryBuffer.reset();
+            if (LOG.isTraceEnabled()) LOG.trace("Received binary from backend for channelId: {}, length: {}", channelId, bytes.length);
+            if (frontendChannel.isOpen()) {
+                CompletableFuture<Void> future = new CompletableFuture<>();
+                WebSockets.sendBinary(ByteBuffer.wrap(bytes), frontendChannel, new io.undertow.websockets.core.WebSocketCallback<Void>() {
+                    @Override
+                    public void complete(WebSocketChannel channel, Void context) {
+                        webSocket.request(1);
+                        future.complete(null);
+                    }
+
+                    @Override
+                    public void onError(WebSocketChannel channel, Void context, Throwable throwable) {
+                        LOG.error("Failed to forward binary message to frontend for channelId: {}", channelId, throwable);
+                        webSocket.request(1);
+                        future.complete(null);
+                    }
+                });
+                return future;
+            }
         }
+        // Non-last fragment or channel closed: request the next fragment immediately
         webSocket.request(1);
-        return null;
+        return CompletableFuture.completedFuture(null);
     }
 
     @Override

--- a/websocket-router/src/main/java/com/networknt/websocket/router/JdkProxyReceiveListener.java
+++ b/websocket-router/src/main/java/com/networknt/websocket/router/JdkProxyReceiveListener.java
@@ -1,0 +1,91 @@
+package com.networknt.websocket.router;
+
+import io.undertow.websockets.core.AbstractReceiveListener;
+import io.undertow.websockets.core.BufferedBinaryMessage;
+import io.undertow.websockets.core.BufferedTextMessage;
+import io.undertow.websockets.core.CloseMessage;
+import io.undertow.websockets.core.WebSocketChannel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xnio.Pooled;
+
+import java.io.IOException;
+import java.net.http.WebSocket;
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+/**
+ * Undertow receive listener for the frontend (client-to-proxy) side that forwards
+ * messages to the backend via JDK HttpClient WebSocket.
+ */
+public class JdkProxyReceiveListener extends AbstractReceiveListener {
+    private static final Logger LOG = LoggerFactory.getLogger(JdkProxyReceiveListener.class);
+
+    private final Map<String, WebSocket> backendChannels;
+    private final String channelId;
+
+    /**
+     * Constructs a new JdkProxyReceiveListener.
+     *
+     * @param backendChannels the map of channelId to JDK WebSocket backend connections
+     * @param channelId the channel identifier for this connection pair
+     */
+    public JdkProxyReceiveListener(Map<String, WebSocket> backendChannels, String channelId) {
+        this.backendChannels = backendChannels;
+        this.channelId = channelId;
+    }
+
+    @Override
+    protected void onFullTextMessage(final WebSocketChannel channel, final BufferedTextMessage message) throws IOException {
+        WebSocket backend = backendChannels.get(channelId);
+        if (backend != null) {
+            String data = message.getData();
+            if (LOG.isTraceEnabled()) LOG.trace("Forwarding text from frontend to backend for channelId: {}, length: {}", channelId, data.length());
+            backend.sendText(data, true);
+        } else {
+            LOG.warn("No backend WebSocket found for channelId: {}", channelId);
+        }
+    }
+
+    @Override
+    protected void onFullBinaryMessage(final WebSocketChannel channel, final BufferedBinaryMessage message) throws IOException {
+        WebSocket backend = backendChannels.get(channelId);
+        if (backend != null) {
+            if (LOG.isTraceEnabled()) LOG.trace("Forwarding binary from frontend to backend for channelId: {}", channelId);
+            Pooled<ByteBuffer[]> pooled = message.getData();
+            try {
+                ByteBuffer[] buffers = pooled.getResource();
+                for (ByteBuffer buf : buffers) {
+                    backend.sendBinary(buf, true);
+                }
+            } finally {
+                pooled.free();
+            }
+        } else {
+            LOG.warn("No backend WebSocket found for channelId: {}", channelId);
+        }
+    }
+
+    @Override
+    protected void onCloseMessage(CloseMessage cm, WebSocketChannel channel) {
+        if (LOG.isDebugEnabled()) LOG.debug("Frontend close for channelId: {}, code: {}, reason: {}", channelId, cm.getCode(), cm.getReason());
+        WebSocket backend = backendChannels.remove(channelId);
+        if (backend != null) {
+            backend.sendClose(cm.getCode(), cm.getReason() != null ? cm.getReason() : "");
+        }
+    }
+
+    @Override
+    protected void onError(final WebSocketChannel channel, final Throwable error) {
+        LOG.error("Frontend WebSocket error for channelId: {}", channelId, error);
+        WebSocket backend = backendChannels.remove(channelId);
+        if (backend != null) {
+            backend.sendClose(WebSocket.NORMAL_CLOSURE, "Frontend error");
+        }
+        try {
+            channel.sendClose();
+        } catch (IOException e) {
+            LOG.error("Failed to close frontend channel for channelId: {}", channelId, e);
+        }
+    }
+}

--- a/websocket-router/src/main/java/com/networknt/websocket/router/JdkProxyReceiveListener.java
+++ b/websocket-router/src/main/java/com/networknt/websocket/router/JdkProxyReceiveListener.java
@@ -52,17 +52,26 @@ public class JdkProxyReceiveListener extends AbstractReceiveListener {
         WebSocket backend = backendChannels.get(channelId);
         if (backend != null) {
             if (LOG.isTraceEnabled()) LOG.trace("Forwarding binary from frontend to backend for channelId: {}", channelId);
+            // Coalesce pooled buffers into a single owned ByteBuffer before freeing the pool.
+            // sendBinary is asynchronous and may read the buffers after this method returns,
+            // so we must not free the pooled buffers until the copy is made.
             Pooled<ByteBuffer[]> pooled = message.getData();
+            ByteBuffer copy;
             try {
                 ByteBuffer[] buffers = pooled.getResource();
-                for (int i = 0; i < buffers.length; i++) {
-                    ByteBuffer buf = buffers[i];
-                    boolean last = (i == buffers.length - 1);
-                    backend.sendBinary(buf, last);
+                int totalBytes = 0;
+                for (ByteBuffer buf : buffers) {
+                    totalBytes += buf.remaining();
                 }
+                copy = ByteBuffer.allocate(totalBytes);
+                for (ByteBuffer buf : buffers) {
+                    copy.put(buf);
+                }
+                copy.flip();
             } finally {
                 pooled.free();
             }
+            backend.sendBinary(copy, true);
         } else {
             LOG.warn("No backend WebSocket found for channelId: {}", channelId);
         }

--- a/websocket-router/src/main/java/com/networknt/websocket/router/JdkProxyReceiveListener.java
+++ b/websocket-router/src/main/java/com/networknt/websocket/router/JdkProxyReceiveListener.java
@@ -55,8 +55,10 @@ public class JdkProxyReceiveListener extends AbstractReceiveListener {
             Pooled<ByteBuffer[]> pooled = message.getData();
             try {
                 ByteBuffer[] buffers = pooled.getResource();
-                for (ByteBuffer buf : buffers) {
-                    backend.sendBinary(buf, true);
+                for (int i = 0; i < buffers.length; i++) {
+                    ByteBuffer buf = buffers[i];
+                    boolean last = (i == buffers.length - 1);
+                    backend.sendBinary(buf, last);
                 }
             } finally {
                 pooled.free();

--- a/websocket-router/src/main/java/com/networknt/websocket/router/JdkProxyReceiveListener.java
+++ b/websocket-router/src/main/java/com/networknt/websocket/router/JdkProxyReceiveListener.java
@@ -59,11 +59,14 @@ public class JdkProxyReceiveListener extends AbstractReceiveListener {
             ByteBuffer copy;
             try {
                 ByteBuffer[] buffers = pooled.getResource();
-                int totalBytes = 0;
+                long totalBytes = 0L;
                 for (ByteBuffer buf : buffers) {
                     totalBytes += buf.remaining();
                 }
-                copy = ByteBuffer.allocate(totalBytes);
+                if (totalBytes > Integer.MAX_VALUE) {
+                    throw new IOException("WebSocket binary message too large: " + totalBytes + " bytes");
+                }
+                copy = ByteBuffer.allocate((int) totalBytes);
                 for (ByteBuffer buf : buffers) {
                     copy.put(buf);
                 }

--- a/websocket-router/src/main/java/com/networknt/websocket/router/WebSocketRouterHandler.java
+++ b/websocket-router/src/main/java/com/networknt/websocket/router/WebSocketRouterHandler.java
@@ -197,11 +197,20 @@ public class WebSocketRouterHandler implements MiddlewareHandler, WebSocketConne
                     String subprotocolHeader = exchange.getRequestHeader("Sec-WebSocket-Protocol");
                     if (subprotocolHeader != null && !subprotocolHeader.isBlank()) {
                         String[] subprotocols = subprotocolHeader.split(",");
+                        ArrayList<String> protocolList = new ArrayList<>();
                         for (String sp : subprotocols) {
                             String trimmed = sp.trim();
                             if (!trimmed.isEmpty()) {
-                                wsBuilder.subprotocols(trimmed);
-                                break; // JDK WebSocket only supports one subprotocol at a time
+                                protocolList.add(trimmed);
+                            }
+                        }
+                        if (!protocolList.isEmpty()) {
+                            String[] protocolsArray = protocolList.toArray(new String[0]);
+                            if (protocolsArray.length == 1) {
+                                wsBuilder.subprotocols(protocolsArray[0]);
+                            } else {
+                                String[] rest = java.util.Arrays.copyOfRange(protocolsArray, 1, protocolsArray.length);
+                                wsBuilder.subprotocols(protocolsArray[0], rest);
                             }
                         }
                     }

--- a/websocket-router/src/main/java/com/networknt/websocket/router/WebSocketRouterHandler.java
+++ b/websocket-router/src/main/java/com/networknt/websocket/router/WebSocketRouterHandler.java
@@ -1,21 +1,18 @@
 package com.networknt.websocket.router;
 
+import com.networknt.client.Http2Client;
 import com.networknt.cluster.Cluster;
 import com.networknt.handler.Handler;
 import com.networknt.handler.MiddlewareHandler;
 import com.networknt.router.RouterConfig;
 import com.networknt.service.SingletonServiceFactory;
 import com.networknt.websocket.client.WsAttributes;
-import com.networknt.websocket.client.WsProxyClientPair;
 import io.undertow.Handlers;
-import io.undertow.client.ProxiedRequestAttachments;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
-import io.undertow.util.Headers;
 import io.undertow.util.PathMatcher;
 import io.undertow.websockets.WebSocketConnectionCallback;
 import io.undertow.websockets.WebSocketProtocolHandshakeHandler;
-import io.undertow.websockets.client.WebSocketClientNegotiation;
 import io.undertow.websockets.core.WebSocketChannel;
 import io.undertow.websockets.core.protocol.Handshake;
 import io.undertow.websockets.core.protocol.version07.Hybi07Handshake;
@@ -25,24 +22,29 @@ import io.undertow.websockets.spi.WebSocketHttpExchange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * WebSocket router handler that proxies WebSocket connections from the frontend
+ * (client) to the backend service. Uses JDK HttpClient for the backend WebSocket
+ * connection to support TLS 1.3.
+ */
 public class WebSocketRouterHandler implements MiddlewareHandler, WebSocketConnectionCallback {
     private static final Logger LOG = LoggerFactory.getLogger(WebSocketRouterHandler.class);
     private static final Cluster CLUSTER = SingletonServiceFactory.getBean(Cluster.class);
     private static final RouterConfig CONFIG = RouterConfig.load();
     private static final WebSocketRouterConfig WS_CONFIG = WebSocketRouterConfig.load();
-    private static final Map<String, WsProxyClientPair> CHANNELS = new ConcurrentHashMap<>();
+    private static final Map<String, WebSocket> BACKEND_CHANNELS = new ConcurrentHashMap<>();
     private static final PathMatcher<String> pathMatcher = new PathMatcher<>();
 
     private volatile HttpHandler next;
@@ -55,6 +57,9 @@ public class WebSocketRouterHandler implements MiddlewareHandler, WebSocketConne
         }
     }
 
+    /**
+     * Default constructor for WebSocketRouterHandler.
+     */
     public WebSocketRouterHandler() {
         // Initialize config or logger if needed
     }
@@ -129,23 +134,6 @@ public class WebSocketRouterHandler implements MiddlewareHandler, WebSocketConne
     
     @Override
     public void onConnect(WebSocketHttpExchange exchange, WebSocketChannel channel) {
-        // Detect protocol from URI if it's absolute, otherwise use a safe default or check context.
-        // The previous startsWith check was always false for relative paths like /chat.
-        // Detect protocol from outgoing request URI if absolute, otherwise use a safe default or check X-Forwarded-Proto
-        String protocol = WsAttributes.WEBSOCKET_PROTOCOL;
-        String xForwardedProto = exchange.getRequestHeader("X-Forwarded-Proto");
-        if ("https".equalsIgnoreCase(xForwardedProto)) {
-            protocol = WsAttributes.WEBSOCKET_SECURE_PROTOCOL;
-        } else {
-            // Check if the current exchange URI is absolute and starts with wss
-            String requestURI = exchange.getRequestURI();
-            if (requestURI != null && requestURI.startsWith(WsAttributes.WEBSOCKET_SECURE_PROTOCOL)) {
-                protocol = WsAttributes.WEBSOCKET_SECURE_PROTOCOL;
-            }
-        }
-
-        if (LOG.isTraceEnabled()) LOG.trace("Detected protocol: {} from request URI: {}", protocol, exchange.getRequestURI());
-
         String serviceId = exchange.getRequestHeader("service_id");
         if(serviceId == null) {
             String requestURI = exchange.getRequestURI();
@@ -161,115 +149,92 @@ public class WebSocketRouterHandler implements MiddlewareHandler, WebSocketConne
         }
         
         if (serviceId != null) {
-            final var downstreamUrl = CLUSTER.serviceToUrl(protocol, serviceId, null, null);
+            // Discover the backend URL using "https" as the service discovery protocol,
+            // since services register with https. Then derive ws/wss from the scheme.
+            final var downstreamUrl = CLUSTER.serviceToUrl("https", serviceId, null, null);
+            if (LOG.isTraceEnabled()) LOG.trace("Discovered downstreamUrl: {} for serviceId: {}", downstreamUrl, serviceId);
             if (downstreamUrl != null) {
                 String channelId = exchange.getRequestHeader(WsAttributes.CHANNEL_GROUP_ID);
                 if (channelId == null) {
                     channelId = java.util.UUID.randomUUID().toString();
                 }
                 
-                if(LOG.isTraceEnabled()) LOG.trace("channelId = {}", channelId);
+                if (LOG.isTraceEnabled()) LOG.trace("channelId = {}", channelId);
                 
-                if (channelId != null) {
-                    channel.setAttribute(WsAttributes.CHANNEL_GROUP_ID, channelId);
-                    channel.setAttribute(WsAttributes.CHANNEL_DIRECTION, WsProxyClientPair.SocketFlow.CLIENT_TO_PROXY);
-                    channel.getReceiveSetter().set(new WebSocketSessionProxyReceiveListener(CHANNELS));
-                    
-                    if (!CHANNELS.containsKey(channelId)) {
-                        try {
-                            final var targetUri = downstreamUrl + exchange.getRequestURI();
-                            final var address = channel.getSourceAddress();
-                            final String remoteHost;
+                // Convert http/https scheme to ws/wss for WebSocket connection
+                String wsBaseUrl;
+                if (downstreamUrl.startsWith("https://")) {
+                    wsBaseUrl = "wss://" + downstreamUrl.substring("https://".length());
+                } else if (downstreamUrl.startsWith("http://")) {
+                    wsBaseUrl = "ws://" + downstreamUrl.substring("http://".length());
+                } else {
+                    wsBaseUrl = downstreamUrl;
+                }
+                final var targetUri = wsBaseUrl + exchange.getRequestURI();
+                if (LOG.isDebugEnabled()) LOG.debug("Connecting to backend WebSocket: {}", targetUri);
 
-                            /* add remote host and remote address attachments */
-                            if (address != null) {
-                                remoteHost = address.getHostString();
-                                if (!address.isUnresolved()) {
-                                    exchange.putAttachment(ProxiedRequestAttachments.REMOTE_ADDRESS, address.getAddress().getHostAddress());
-                                }
-                            } else remoteHost = "localhost";
-                            exchange.putAttachment(ProxiedRequestAttachments.REMOTE_HOST, remoteHost);
-
-                            /* add server name attachment */
-                            String host;
-                            if (CONFIG.isReuseXForwarded()) {
-                                host = exchange.getRequestHeader(Headers.X_FORWARDED_SERVER_STRING);
-                            } else {
-                                host = exchange.getRequestHeader(Headers.HOST_STRING);
-                                if (host == null || "".equals(host.trim())) {
-                                    host  = channel.getDestinationAddress().getHostString();
-                                } else {
-                                    if (host.startsWith("[")) {
-                                        host = host.substring(1, host.indexOf(']'));
-                                    } else if (host.indexOf(':') != -1) {
-                                        host = host.substring(0, host.indexOf(':'));
-                                    }
-                                }
-                            }
-                            exchange.putAttachment(ProxiedRequestAttachments.SERVER_NAME, host);
-
-                            /* attach x-forwarded-port */
-                            String port;
-                            if (CONFIG.isReuseXForwarded() && exchange.getRequestHeader(Headers.X_FORWARDED_PORT_STRING) != null) {
-                                try {
-                                    port = exchange.getRequestHeader(Headers.X_FORWARDED_PORT_STRING);
-                                    exchange.putAttachment(ProxiedRequestAttachments.SERVER_PORT, Integer.parseInt(port));
-
-                                } catch (NumberFormatException e) {
-                                    port = String.valueOf(channel.getDestinationAddress().getPort());
-                                    exchange.putAttachment(ProxiedRequestAttachments.SERVER_PORT, Integer.parseInt(port));
-                                }
-                            } else {
-                                port = String.valueOf(channel.getDestinationAddress().getPort());
-                                exchange.putAttachment(ProxiedRequestAttachments.SERVER_PORT, Integer.parseInt(port));
-                            }
-
-                            /* create new connection to downstream */
-                            String subprotocolHeader = exchange.getRequestHeader("Sec-WebSocket-Protocol");
-                            final List<String> subprotocols = new ArrayList<>();
-                            if (subprotocolHeader != null) {
-                                for (String token : subprotocolHeader.split(",")) {
-                                    String trimmed = token.trim();
-                                    if (!trimmed.isEmpty()) {
-                                        subprotocols.add(trimmed);
-                                    }
-                                }
-                            }
-                            WebSocketClientNegotiation negotiation = new WebSocketClientNegotiation(subprotocols, Collections.emptyList()) {
-                                @Override
-                                public void beforeRequest(Map<String, List<String>> headers) {
-                                    if (!subprotocols.isEmpty()) {
-                                        headers.put("Sec-WebSocket-Protocol", Collections.singletonList(String.join(", ", subprotocols)));
-                                    }
-                                    String authorization = exchange.getRequestHeader(Headers.AUTHORIZATION_STRING);
-                                    if (authorization != null && !authorization.isBlank()) {
-                                        headers.put(Headers.AUTHORIZATION_STRING, Collections.singletonList(authorization));
-                                    }
-                                }
-                            };
-
-                            final var webSocketConnection = new io.undertow.websockets.client.WebSocketClient.ConnectionBuilder(
-                                    channel.getWorker(),
-                                    channel.getBufferPool(),
-                                    new URI(targetUri)
-                            ).setClientNegotiation(negotiation);
-                            final var outChannel = webSocketConnection.connect().get();
-                            outChannel.setAttribute(WsAttributes.CHANNEL_GROUP_ID, channelId);
-                            outChannel.setAttribute(WsAttributes.CHANNEL_DIRECTION, WsProxyClientPair.SocketFlow.PROXY_TO_DOWNSTREAM);
-                            outChannel.getReceiveSetter().set(new WebSocketSessionProxyReceiveListener(CHANNELS));
-                            CHANNELS.put(channelId, new WsProxyClientPair(channel, outChannel));
-                            outChannel.resumeReceives();
-                        } catch (URISyntaxException | IOException e) {
-                            LOG.error("Failed to create connection to the backend.", e);
-                            try {
-                                channel.sendClose();
-                            } catch (IOException ex) {
-                                throw new RuntimeException(ex);
-                            }
-                            exchange.endExchange();
+                // Set the frontend receive listener to forward messages to the backend
+                channel.getReceiveSetter().set(new JdkProxyReceiveListener(BACKEND_CHANNELS, channelId));
+                
+                try {
+                    // Build JDK HttpClient with SSL support
+                    HttpClient.Builder httpClientBuilder = HttpClient.newBuilder();
+                    if (targetUri.startsWith("wss://")) {
+                        SSLContext sslContext = Http2Client.createSSLContext();
+                        if (sslContext != null) {
+                            httpClientBuilder.sslContext(sslContext);
                         }
                     }
+                    HttpClient httpClient = httpClientBuilder.build();
+
+                    // Build the WebSocket connection with authorization header if present
+                    java.net.http.WebSocket.Builder wsBuilder = httpClient.newWebSocketBuilder();
+                    String authorization = exchange.getRequestHeader("Authorization");
+                    if (authorization != null && !authorization.isBlank()) {
+                        wsBuilder.header("Authorization", authorization);
+                    }
+                    // Forward subprotocols if present
+                    String subprotocolHeader = exchange.getRequestHeader("Sec-WebSocket-Protocol");
+                    if (subprotocolHeader != null && !subprotocolHeader.isBlank()) {
+                        String[] subprotocols = subprotocolHeader.split(",");
+                        for (String sp : subprotocols) {
+                            String trimmed = sp.trim();
+                            if (!trimmed.isEmpty()) {
+                                wsBuilder.subprotocols(trimmed);
+                                break; // JDK WebSocket only supports one subprotocol at a time
+                            }
+                        }
+                    }
+
+                    // Connect to the backend using JDK WebSocket client
+                    final String finalChannelId = channelId;
+                    WebSocket backendWs = wsBuilder
+                            .buildAsync(new URI(targetUri), new JdkBackendWebSocketListener(channel, channelId))
+                            .join();
+
+                    // Store the backend connection
+                    BACKEND_CHANNELS.put(channelId, backendWs);
+                    if (LOG.isDebugEnabled()) LOG.debug("Backend WebSocket connected for channelId: {}", channelId);
+
+                    // Set up close listener on the frontend channel to clean up
+                    channel.addCloseTask(ch -> {
+                        if (LOG.isDebugEnabled()) LOG.debug("Frontend channel closed, cleaning up channelId: {}", finalChannelId);
+                        WebSocket removed = BACKEND_CHANNELS.remove(finalChannelId);
+                        if (removed != null && !removed.isOutputClosed()) {
+                            removed.sendClose(WebSocket.NORMAL_CLOSURE, "Frontend closed");
+                        }
+                    });
+
                     channel.resumeReceives();
+
+                } catch (Exception e) {
+                    LOG.error("Failed to create backend WebSocket connection to: {}", targetUri, e);
+                    BACKEND_CHANNELS.remove(channelId);
+                    try {
+                        channel.sendClose();
+                    } catch (IOException ex) {
+                        LOG.error("Failed to close frontend channel", ex);
+                    }
                 }
             } else {
                 LOG.error("Could not find downstream URL for serviceId: {}", serviceId);

--- a/websocket-router/src/main/java/com/networknt/websocket/router/WebSocketRouterHandler.java
+++ b/websocket-router/src/main/java/com/networknt/websocket/router/WebSocketRouterHandler.java
@@ -206,29 +206,39 @@ public class WebSocketRouterHandler implements MiddlewareHandler, WebSocketConne
                         }
                     }
 
-                    // Connect to the backend using JDK WebSocket client
+                    // Connect to the backend asynchronously to avoid blocking the I/O thread
                     final String finalChannelId = channelId;
-                    WebSocket backendWs = wsBuilder
+                    wsBuilder
                             .buildAsync(new URI(targetUri), new JdkBackendWebSocketListener(channel, channelId))
-                            .join();
+                            .whenComplete((backendWs, ex) -> {
+                                if (ex != null) {
+                                    LOG.error("Failed to create backend WebSocket connection to: {}", targetUri, ex);
+                                    BACKEND_CHANNELS.remove(finalChannelId);
+                                    try {
+                                        channel.sendClose();
+                                    } catch (IOException closeEx) {
+                                        LOG.error("Failed to close frontend channel", closeEx);
+                                    }
+                                } else {
+                                    // Store the backend connection
+                                    BACKEND_CHANNELS.put(finalChannelId, backendWs);
+                                    if (LOG.isDebugEnabled()) LOG.debug("Backend WebSocket connected for channelId: {}", finalChannelId);
 
-                    // Store the backend connection
-                    BACKEND_CHANNELS.put(channelId, backendWs);
-                    if (LOG.isDebugEnabled()) LOG.debug("Backend WebSocket connected for channelId: {}", channelId);
+                                    // Set up close listener on the frontend channel to clean up
+                                    channel.addCloseTask(ch -> {
+                                        if (LOG.isDebugEnabled()) LOG.debug("Frontend channel closed, cleaning up channelId: {}", finalChannelId);
+                                        WebSocket removed = BACKEND_CHANNELS.remove(finalChannelId);
+                                        if (removed != null && !removed.isOutputClosed()) {
+                                            removed.sendClose(WebSocket.NORMAL_CLOSURE, "Frontend closed");
+                                        }
+                                    });
 
-                    // Set up close listener on the frontend channel to clean up
-                    channel.addCloseTask(ch -> {
-                        if (LOG.isDebugEnabled()) LOG.debug("Frontend channel closed, cleaning up channelId: {}", finalChannelId);
-                        WebSocket removed = BACKEND_CHANNELS.remove(finalChannelId);
-                        if (removed != null && !removed.isOutputClosed()) {
-                            removed.sendClose(WebSocket.NORMAL_CLOSURE, "Frontend closed");
-                        }
-                    });
-
-                    channel.resumeReceives();
+                                    channel.resumeReceives();
+                                }
+                            });
 
                 } catch (Exception e) {
-                    LOG.error("Failed to create backend WebSocket connection to: {}", targetUri, e);
+                    LOG.error("Failed to set up backend WebSocket connection to: {}", targetUri, e);
                     BACKEND_CHANNELS.remove(channelId);
                     try {
                         channel.sendClose();

--- a/websocket-router/src/main/java/com/networknt/websocket/router/WebSocketRouterHandler.java
+++ b/websocket-router/src/main/java/com/networknt/websocket/router/WebSocketRouterHandler.java
@@ -220,6 +220,17 @@ public class WebSocketRouterHandler implements MiddlewareHandler, WebSocketConne
                                         LOG.error("Failed to close frontend channel", closeEx);
                                     }
                                 } else {
+                                    // Guard against the frontend channel having closed while the
+                                    // async backend connect was in flight; if so, close the backend
+                                    // immediately and skip storing it to prevent a connection/map leak.
+                                    if (!channel.isOpen()) {
+                                        LOG.warn("Frontend channel already closed before backend connected, channelId: {}", finalChannelId);
+                                        if (!backendWs.isOutputClosed()) {
+                                            backendWs.sendClose(WebSocket.NORMAL_CLOSURE, "Frontend closed");
+                                        }
+                                        return;
+                                    }
+
                                     // Store the backend connection
                                     BACKEND_CHANNELS.put(finalChannelId, backendWs);
                                     if (LOG.isDebugEnabled()) LOG.debug("Backend WebSocket connected for channelId: {}", finalChannelId);


### PR DESCRIPTION
Replaces the Undertow WebSocket client with the JDK `java.net.http.HttpClient`/`WebSocket` implementation to support TLS 1.3 for backend WebSocket connections.

## Changes Made

- **`WebSocketRouterHandler`**: Switches backend WebSocket dialing to JDK `HttpClient`. Backend connection is established fully asynchronously via `whenComplete` (no blocking of the Undertow I/O thread). A `channel.isOpen()` guard in the success callback prevents a connection/map leak if the frontend closes before the async connect completes.
- **`JdkProxyReceiveListener`**: Coalesces all pooled `ByteBuffer`s into a single owned copy before freeing the pool, so the async `sendBinary` call never reads from freed memory.
- **`JdkBackendWebSocketListener`**: Accumulates fragmented text and binary messages until the `last` flag is set before forwarding to the Undertow frontend. Binary chunks are copied immediately from the JDK-owned `ByteBuffer` on each callback. Backpressure is applied on the backend→frontend path: `webSocket.request(1)` is called only inside the send callback (after the Undertow send completes), and a `CompletionStage` is returned to gate delivery of the next message.
- **`pom.xml`**: Adds `com.networknt:client` dependency for SSL/TLS context creation.

## Testing

- Build and tests pass (`mvn test` on `websocket-router` module)
- Code review and CodeQL security scan passed